### PR TITLE
chore: Add `libpq-dev` and `curl` to python v3.11 image

### DIFF
--- a/dind/v25/Dockerfile
+++ b/dind/v25/Dockerfile
@@ -8,6 +8,7 @@ FROM ${base_image}
 # Set to skip prompt during USG audit
 ENV DEBIAN_FRONTEND=noninteractive
 
+
 ENV DOCKER_COMPOSE_VERSION 2.24.5
 ENV DOCKER_VERSION 25.0.1
 ENV DOCKER_BUILDX_VERSION 0.12.1

--- a/python/v3.11/Dockerfile
+++ b/python/v3.11/Dockerfile
@@ -21,6 +21,7 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
         build-essential \
         ca-certificates \
+		curl \
         iptables \
 		libbluetooth-dev \
         libncurses5-dev \
@@ -31,6 +32,7 @@ RUN set -eux; \
         libffi-dev \
         libsqlite3-dev \
         libbz2-dev \
+		libpq-dev \
         openssl \
 		tk-dev \
 		uuid-dev \


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add `libpq-dev` and `curl` to python v3.11 image

## security considerations
None