### PR TITLE
chore: add build-essential, git, and libpq to node image

### DIFF
--- a/node/v20/Dockerfile
+++ b/node/v20/Dockerfile
@@ -12,83 +12,86 @@ ENV DEBIAN_FRONTEND=noninteractive
 #   && useradd --uid 1063 --gid node --shell /bin/bash --create-home node
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates \
-        curl \
-        wget \
-        gnupg \
-        dirmngr \
-        xz-utils \
-        libatomic1 \
-        iptables \
-        nftables \
-        openssl \
-        openssh-client \
-        uidmap \
-        xfsprogs \
-        pigz \
-        zfsutils-linux \
-        zfs-dkms \
-        zfs-zed
+  build-essential \
+  ca-certificates \
+  curl \
+  wget \
+  git \
+  gnupg \
+  dirmngr \
+  xz-utils \
+  libatomic1 \
+  libpq-dev \
+  iptables \
+  nftables \
+  openssl \
+  openssh-client \
+  uidmap \
+  xfsprogs \
+  pigz \
+  zfsutils-linux \
+  zfs-dkms \
+  zfs-zed
 
 RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
-    && case "${dpkgArch##*-}" in \
-      amd64) ARCH='x64' OPENSSL_ARCH='linux-x86_64';; \
-      ppc64el) ARCH='ppc64le' OPENSSL_ARCH='linux-ppc64le';; \
-      s390x) ARCH='s390x' OPENSSL_ARCH='linux*-s390x';; \
-      arm64) ARCH='arm64' OPENSSL_ARCH='linux-aarch64';; \
-      armhf) ARCH='armv7l' OPENSSL_ARCH='linux-armv4';; \
-      i386) ARCH='x86' OPENSSL_ARCH='linux-elf';; \
-      *) echo "unsupported architecture"; exit 1 ;; \
-    esac \
-    # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150
-    && export GNUPGHOME="$(mktemp -d)" \
-    # gpg keys listed at https://github.com/nodejs/node#release-keys
-    && for key in \
-      4ED778F539E3634C779C87C6D7062848A1AB005C \
-      141F07595B7B3FFE74309A937405533BE57C7D57 \
-      74F12602B6F1C4E913FAA37AD3A89613643B6201 \
-      DD792F5973C6DE52C432CBDAC77ABFA00DDBF2B7 \
-      61FC681DFB92A079F1685E77973F295594EC4689 \
-      8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
-      C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-      890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4 \
-      C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
-      108F52B48DB57BB0CC439B2997B01419BD92F80A \
-      A363A499291CBBC940DD62E41F10027AF002F8B0 \
-    ; do \
-      gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
-      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
-    done \
-    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
-    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
-    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
-    && gpgconf --kill all \
-    && rm -rf "$GNUPGHOME" \
-    && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
-    && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
-    && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-    # Remove unused OpenSSL headers to save ~34MB. See this NodeJS issue: https://github.com/nodejs/node/issues/46451
-    && find /usr/local/include/node/openssl/archs -mindepth 1 -maxdepth 1 ! -name "$OPENSSL_ARCH" -exec rm -rf {} \; \
-    && apt-mark auto '.*' > /dev/null \
-    && find /usr/local -type f -executable -exec ldd '{}' ';' \
-      | awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
-      | sort -u \
-      | xargs -r dpkg-query --search \
-      | cut -d: -f1 \
-      | sort -u \
-      | xargs -r apt-mark manual \
-    && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
-    # smoke tests
-    && node --version \
-    && npm --version
+  && case "${dpkgArch##*-}" in \
+  amd64) ARCH='x64' OPENSSL_ARCH='linux-x86_64';; \
+  ppc64el) ARCH='ppc64le' OPENSSL_ARCH='linux-ppc64le';; \
+  s390x) ARCH='s390x' OPENSSL_ARCH='linux*-s390x';; \
+  arm64) ARCH='arm64' OPENSSL_ARCH='linux-aarch64';; \
+  armhf) ARCH='armv7l' OPENSSL_ARCH='linux-armv4';; \
+  i386) ARCH='x86' OPENSSL_ARCH='linux-elf';; \
+  *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150
+  && export GNUPGHOME="$(mktemp -d)" \
+  # gpg keys listed at https://github.com/nodejs/node#release-keys
+  && for key in \
+  4ED778F539E3634C779C87C6D7062848A1AB005C \
+  141F07595B7B3FFE74309A937405533BE57C7D57 \
+  74F12602B6F1C4E913FAA37AD3A89613643B6201 \
+  DD792F5973C6DE52C432CBDAC77ABFA00DDBF2B7 \
+  61FC681DFB92A079F1685E77973F295594EC4689 \
+  8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+  C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+  890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4 \
+  C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
+  108F52B48DB57BB0CC439B2997B01419BD92F80A \
+  A363A499291CBBC940DD62E41F10027AF002F8B0 \
+  ; do \
+  gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+  gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && gpgconf --kill all \
+  && rm -rf "$GNUPGHOME" \
+  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  # Remove unused OpenSSL headers to save ~34MB. See this NodeJS issue: https://github.com/nodejs/node/issues/46451
+  && find /usr/local/include/node/openssl/archs -mindepth 1 -maxdepth 1 ! -name "$OPENSSL_ARCH" -exec rm -rf {} \; \
+  && apt-mark auto '.*' > /dev/null \
+  && find /usr/local -type f -executable -exec ldd '{}' ';' \
+  | awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
+  | sort -u \
+  | xargs -r dpkg-query --search \
+  | cut -d: -f1 \
+  | sort -u \
+  | xargs -r apt-mark manual \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  # smoke tests
+  && node --version \
+  && npm --version
 
 RUN savedAptMark="$(apt-mark showmanual)" \
   && export GNUPGHOME="$(mktemp -d)" \
   && for key in \
-    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  6A010C5166006599AA17F08146C2130DFD2497F5 \
   ; do \
-    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
-    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+  gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+  gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
   done \
   && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
   && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
@@ -103,19 +106,19 @@ RUN savedAptMark="$(apt-mark showmanual)" \
   && apt-mark auto '.*' > /dev/null \
   && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; } \
   && find /usr/local -type f -executable -exec ldd '{}' ';' \
-    | awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
-    | sort -u \
-    | xargs -r dpkg-query --search \
-    | cut -d: -f1 \
-    | sort -u \
-    | xargs -r apt-mark manual \
+  | awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
+  | sort -u \
+  | xargs -r dpkg-query --search \
+  | cut -d: -f1 \
+  | sort -u \
+  | xargs -r apt-mark manual \
   # smoke test
   && yarn --version
 
 COPY docker-entrypoint.sh /usr/local/bin/
 
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh; \
-    export PATH="/usr/local/bin/:$PATH";
+  export PATH="/usr/local/bin/:$PATH";
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- add `build-essential`, `git`, and `libpq-dev` to node image

## security considerations
Adding additional build tools to a hardened image