### PR TITLE
fix: Zap image to pass USG audit

### DIFF
--- a/zap/Dockerfile
+++ b/zap/Dockerfile
@@ -112,8 +112,6 @@ RUN chown -R 1000:1000 /zap
 COPY --link --chown=1000:1000 policies /home/zap/.ZAP/policies/
 RUN usermod --shell /bin/false zap
 
-USER zap
-
 ENV PATH=$JAVA_HOME/bin:/zap/:$PATH
 ENV ZAP_PATH=/zap/zap.sh
 ENV HOME=/home/zap/


### PR DESCRIPTION
## Changes proposed in this pull request:

- Does not set the `USER` to `zap` so the USG audit task can run as root user in CI

## security considerations
Enables Zap image to run the USG audit task
