### PR TITLE
set the sticky bit on folders

### DIFF
--- a/postgres/v15/Dockerfile
+++ b/postgres/v15/Dockerfile
@@ -83,7 +83,7 @@ RUN set -eux; \
     sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/share/postgresql/postgresql.conf.sample; \
     grep -F "listen_addresses = '*'" /usr/share/postgresql/postgresql.conf.sample
 
-RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 1777 /var/run/postgresql
+RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 3777 /var/run/postgresql
 
 ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 1777 "$PGDATA"


### PR DESCRIPTION
## Changes proposed in this pull request:
- Setting permissions to 1777 sets the sticky bit which prevents deletion of the folder by other users

## security considerations
Setting the sticky bit on public folders is required by disa stig